### PR TITLE
Add configuration to generate logstash friendly access logs

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -14,7 +14,7 @@ events {
 }
 
 http {
-    log_format logstash_json '{ "@timestamp": "$time_iso8601", '
+    log_format logstash_json escape=json '{ "@timestamp": "$time_iso8601", '
                          '"@fields": { '
                          '"remote_addr": "$remote_addr", '
                          '"remote_user": "$remote_user", '

--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -14,11 +14,21 @@ events {
 }
 
 http {
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format logstash_json '{ "@timestamp": "$time_iso8601", '
+                         '"@fields": { '
+                         '"remote_addr": "$remote_addr", '
+                         '"remote_user": "$remote_user", '
+                         '"body_bytes_sent": "$body_bytes_sent", '
+                         '"request_time": "$request_time", '
+                         '"status": "$status", '
+                         '"request": "$request", '
+                         '"request_method": "$request_method", '
+                         '"http_referrer": "$http_referer", '
+                         '"http_x_forwarded_for": "$http_x_forwarded_for", '
+                         '"http_user_agent": "$http_user_agent" } }';
 
-    access_log 		/dev/stdout main;
+    access_log /dev/stdout logstash_json;
+
     client_body_temp_path /tmp;
     fastcgi_temp_path /tmp;
     scgi_temp_path /tmp;
@@ -49,7 +59,7 @@ http {
         location / {
           etag off;
           if_modified_since off;
-          more_clear_headers 'Last-Modified';          
+          more_clear_headers 'Last-Modified';
         }
 
         location /_assets/ {


### PR DESCRIPTION
I show an example of the output in json format:
```
{ "@timestamp": "2017-06-12T19:07:54+00:00", "@fields": { "remote_addr": "172.17.0.1", "remote_user": "-", "body_bytes_sent": "169", "request_time": "0.000", "status": "403", "request": "GET / HTTP/1.1", "request_method": "GET", "http_referrer": "-", "http_x_forwarded_for": "-", "http_user_agent": "curl/7.35.0" } }
```

whole log of the container:
```
2017/06/12 19:07:43 [notice] 18#0: using the "epoll" event method
2017/06/12 19:07:43 [notice] 18#0: nginx/1.10.2
2017/06/12 19:07:43 [notice] 18#0: built by gcc 4.8.5 20150623 (Red Hat 4.8.5-11) (GCC)
2017/06/12 19:07:43 [notice] 18#0: OS: Linux 3.13.0-92-generic
2017/06/12 19:07:43 [notice] 18#0: getrlimit(RLIMIT_NOFILE): 524288:1048576
2017/06/12 19:07:43 [notice] 18#0: start worker processes
2017/06/12 19:07:43 [notice] 18#0: start worker process 19
2017/06/12 19:07:54 [error] 19#0: *1 directory index of "/usr/share/nginx/html/" is forbidden, client: 172.17.0.1, server: _, request: "GET / HTTP/1.1", host: "localhost:8086"
{ "@timestamp": "2017-06-12T19:07:54+00:00", "@fields": { "remote_addr": "172.17.0.1", "remote_user": "-", "body_bytes_sent": "169", "request_time": "0.000", "status": "403", "request": "GET / HTTP/1.1", "request_method": "GET", "http_referrer": "-", "http_x_forwarded_for": "-", "http_user_agent": "curl/7.35.0" } }
2017/06/12 19:07:54 [info] 19#0: *1 client 172.17.0.1 closed keepalive connection
```