### PR TITLE
Removed escape=json because we run an older version of nginx 1.11.8

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -14,7 +14,7 @@ events {
 }
 
 http {
-    log_format logstash_json escape=json '{ "@timestamp": "$time_iso8601", '
+    log_format logstash_json '{ "@timestamp": "$time_iso8601", '
                          '"@fields": { '
                          '"remote_addr": "$remote_addr", '
                          '"remote_user": "$remote_user", '


### PR DESCRIPTION
`escape=json` is a feature available on nginx version >= 1.11.8. We should remove this definition until we upgrade our nginx version that comes with centos7.

@kbsingh Could we upgrade the nginx version that generally comes with centos7 ?

@aslakknutsen for review