### PR TITLE
Avoid everlasting DNS cache on changing Amazon ELB DNS

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -71,6 +71,11 @@ http {
         }
 
         # CORS proxy to OSO
+        # Avoid Nginx caching DNS lookup for ever, causing problems when
+        # combined with changing DNS, e.g. Amazon ELB
+        # https://tenzer.dk/nginx-with-dynamic-upstreams/
+        resolver 8.8.8.8;
+        set $oso ${PROXY_PASS_URL};
         location ~ /_p/oso/(?<path>.*) {
           proxy_redirect off;
           proxy_set_header Host $host;
@@ -98,7 +103,7 @@ http {
           if ($cors = "1") {
             more_set_headers 'Access-Control-Allow-Origin: *';
             more_set_headers 'Access-Control-Allow-Credentials: true';
-            proxy_pass      ${PROXY_PASS_URL}/$path;
+            proxy_pass      $oso/$path;
           }
 
           # OPTIONS (pre-flight) request from allowed
@@ -113,7 +118,7 @@ http {
             return 204;
           }
 
-          proxy_pass      ${PROXY_PASS_URL};
+          proxy_pass      $oso;
         }
 
         # This is added to support pushState URL patterm


### PR DESCRIPTION
Amazon ELB has a 60s DNS TTL, while nginx by default
cache the lookup until config is reloaded.

Eventually the nginx proxy will be holding bad ips
and all calls to the proxy_pass times out.

Ref https://tenzer.dk/nginx-with-dynamic-upstreams/

Related to openshiftio/openshift.io#535
Realted to openshiftio/openshift.io#558