### PR TITLE
get version value outside of the docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,11 +36,10 @@ dockerNode{
       } else if (utils.isCD()){
         git "https://github.com/${project}.git"
         sh "git remote set-url origin git@github.com:${project}.git"
-
+        def version
+        version = utils.getLatestVersionFromTag()
+        
         container(name: 'docker') {
-          def version
-          version = utils.getLatestVersionFromTag()
-
           stage ('build snapshot image'){
               sh "docker build -t ${imageName}:${version} ."
           }


### PR DESCRIPTION
The build failed due to: http://jenkins.cd.k8s.fabric8.io/blue/organizations/jenkins/fabric8-ui%2Ffabric8-ui-openshift-nginx/detail/master/3/pipeline

```
+ git fetch --tags
/home/jenkins/workspace/8-ui-openshift-nginx_master-IBYF6QXL3H2G2R4SVWROMZ2GPRTXQY7O5M3GVJAKHKVWELLCTC7Q@tmp/durable-a86e17eb/script.sh: line 1: git: not found
script returned exit code 127
```