### PR TITLE
Enable browser cache for assets

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -70,57 +70,6 @@ http {
           # expires 1y;
         }
 
-        # CORS proxy to OSO
-        # Avoid Nginx caching DNS lookup for ever, causing problems when
-        # combined with changing DNS, e.g. Amazon ELB
-        # https://tenzer.dk/nginx-with-dynamic-upstreams/
-        resolver 8.8.8.8;
-        set $oso ${PROXY_PASS_URL};
-        location ~ /_p/oso/(?<path>.*) {
-          proxy_redirect off;
-          proxy_set_header Host $host;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-          # Nginx doesn't support nested If statements, so we
-          # concatenate compound conditions on the $cors variable
-          # and process later
-
-          # If request comes from allowed subdomain
-          # (*.mckinsey.com) then we enable CORS
-
-          set $cors "0";
-          #if ($http_origin ~* (https?://.*\.openshift.io(:[0-9]+)?$)) {
-            set $cors "1";
-          #}
-
-          # OPTIONS indicates a CORS pre-flight request
-          if ($request_method = 'OPTIONS') {
-            set $cors "${cors}o";
-          }
-
-          # Append CORS headers to any request from
-          # allowed CORS domain, except OPTIONS
-          if ($cors = "1") {
-            more_set_headers 'Access-Control-Allow-Origin: *';
-            more_set_headers 'Access-Control-Allow-Credentials: true';
-            proxy_pass      $oso/$path;
-          }
-
-          # OPTIONS (pre-flight) request from allowed
-          # CORS domain. return response directly
-          if ($cors = "1o") {
-            more_set_headers 'Access-Control-Allow-Origin: $http_origin';
-            more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE';
-            more_set_headers 'Access-Control-Allow-Credentials: true';
-            more_set_headers 'Access-Control-Allow-Headers: Origin,Content-Type,Accept';
-            add_header Content-Length 0;
-            add_header Content-Type text/plain;
-            return 204;
-          }
-
-          proxy_pass      $oso;
-        }
-
         # This is added to support pushState URL patterm
         # Redirecting every 404 to angular APP and
         # let the APP handle

--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -60,6 +60,9 @@ http {
           etag off;
           if_modified_since off;
           more_clear_headers 'Last-Modified';
+          location =/index.html {
+            expires epoch;
+          }
         }
 
         location /_assets/ {
@@ -67,7 +70,7 @@ http {
           gzip on;
           if_modified_since off;
           more_clear_headers 'Last-Modified';
-          # expires 1y;
+          expires 1y;
         }
 
         # This is added to support pushState URL patterm


### PR DESCRIPTION
This PR enables browser cache for all the resource under '_assets' directory for [fabric8-ui](https://github.com/fabric8-ui/fabric8-ui) application.

Fix - https://github.com/fabric8-ui/fabric8-ui-openshift-nginx/issues/18