### PR TITLE
Fixing cccp yaml job id to match that provided in container index.

### DIFF
--- a/cccp.yml
+++ b/cccp.yml
@@ -1,4 +1,4 @@
-job-id: fabric8-ui-openshift-nginx
+job-id: openshift-nginx
 
 #the following are optional, can be left blank
 #defaults, where applicable are filled in


### PR DESCRIPTION
The job-id in cccp yaml is not the same as the value given in the index. This PR moves to fix the same.
Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>